### PR TITLE
Add left/right/undecided voting and comma-separated multi-add

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>推し度チェッカー</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="app">
+      <header>
+        <h1>推し度チェッカー</h1>
+        <p>二択に答えて、あなたの推しランキングを作ろう。</p>
+      </header>
+
+      <section class="panel">
+        <h2>推しをランキングに追加</h2>
+        <div class="form-row">
+          <input id="character-input" type="text" placeholder="推しの名前（カンマ区切りで複数追加可）" />
+          <button id="add-character" type="button">追加</button>
+        </div>
+        <p class="hint">2人以上登録すると対戦が始まります。</p>
+      </section>
+
+      <section class="panel matchup" aria-live="polite">
+        <h2>どっちが好き？</h2>
+        <div id="matchup-area" class="matchup-area">
+          <p class="empty">キャラクターを登録してください。</p>
+        </div>
+        <div class="actions">
+          <button id="vote-a" type="button" class="choice" disabled>左が好き</button>
+          <button id="vote-draw" type="button" class="choice neutral" disabled>決められない</button>
+          <button id="vote-b" type="button" class="choice" disabled>右が好き</button>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-header">
+          <h2>ランキング</h2>
+          <button id="reset-data" type="button" class="ghost">データをリセット</button>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>順位</th>
+                <th>キャラクター</th>
+                <th>推し度</th>
+                <th>成績</th>
+                <th>操作</th>
+              </tr>
+            </thead>
+            <tbody id="ranking-body"></tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,198 @@
+const STORAGE_KEY = "oshi-data";
+const K_FACTOR = 32;
+
+const characterInput = document.getElementById("character-input");
+const addCharacterButton = document.getElementById("add-character");
+const matchupArea = document.getElementById("matchup-area");
+const voteAButton = document.getElementById("vote-a");
+const voteBButton = document.getElementById("vote-b");
+const voteDrawButton = document.getElementById("vote-draw");
+const rankingBody = document.getElementById("ranking-body");
+const resetButton = document.getElementById("reset-data");
+
+let state = loadState();
+let currentPair = null;
+
+function loadState() {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    return { characters: [] };
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed.characters) {
+      return { characters: [] };
+    }
+    return parsed;
+  } catch (error) {
+    return { characters: [] };
+  }
+}
+
+function saveState() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+function createCharacter(name) {
+  return {
+    id: Date.now().toString(36) + Math.random().toString(36).slice(2),
+    name,
+    rating: 1000,
+    wins: 0,
+    losses: 0,
+    draws: 0,
+  };
+}
+
+function addCharacter() {
+  const raw = characterInput.value.trim();
+  if (!raw) {
+    return;
+  }
+  const names = raw
+    .split(/[,、]/)
+    .map((name) => name.trim())
+    .filter(Boolean);
+  const existingNames = new Set(state.characters.map((character) => character.name));
+  const uniqueNames = names.filter((name) => !existingNames.has(name));
+
+  if (!uniqueNames.length) {
+    alert("同じ名前のキャラクターが登録されています。");
+    return;
+  }
+
+  uniqueNames.forEach((name) => {
+    state.characters.push(createCharacter(name));
+  });
+
+  characterInput.value = "";
+  saveState();
+  refresh();
+}
+
+function removeCharacter(id) {
+  state.characters = state.characters.filter((character) => character.id !== id);
+  saveState();
+  refresh();
+}
+
+function getRandomPair() {
+  if (state.characters.length < 2) {
+    return null;
+  }
+  const indices = [...state.characters.keys()];
+  const firstIndex = indices.splice(Math.floor(Math.random() * indices.length), 1)[0];
+  const secondIndex = indices[Math.floor(Math.random() * indices.length)];
+  return [state.characters[firstIndex], state.characters[secondIndex]];
+}
+
+function expectedScore(ratingA, ratingB) {
+  return 1 / (1 + 10 ** ((ratingB - ratingA) / 400));
+}
+
+function updateRatings(result) {
+  if (!currentPair) {
+    return;
+  }
+  const [charA, charB] = currentPair;
+  const scoreA = result;
+  const scoreB = 1 - result;
+  const expectedA = expectedScore(charA.rating, charB.rating);
+  const expectedB = expectedScore(charB.rating, charA.rating);
+
+  charA.rating = Math.round(charA.rating + K_FACTOR * (scoreA - expectedA));
+  charB.rating = Math.round(charB.rating + K_FACTOR * (scoreB - expectedB));
+
+  if (result === 1) {
+    charA.wins += 1;
+    charB.losses += 1;
+  } else if (result === 0) {
+    charA.losses += 1;
+    charB.wins += 1;
+  } else {
+    charA.draws += 1;
+    charB.draws += 1;
+  }
+
+  saveState();
+  refresh();
+}
+
+function renderMatchup() {
+  if (state.characters.length < 2) {
+    matchupArea.innerHTML = '<p class="empty">キャラクターを登録してください。</p>';
+    voteAButton.disabled = true;
+    voteBButton.disabled = true;
+    voteDrawButton.disabled = true;
+    return;
+  }
+
+  currentPair = getRandomPair();
+  if (!currentPair) {
+    return;
+  }
+
+  const [charA, charB] = currentPair;
+  matchupArea.innerHTML = `
+    <div class="matchup-card">
+      <span class="side">左</span>
+      <div>${charA.name}</div>
+    </div>
+    <div class="matchup-card">
+      <span class="side">右</span>
+      <div>${charB.name}</div>
+    </div>
+  `;
+  voteAButton.disabled = false;
+  voteBButton.disabled = false;
+  voteDrawButton.disabled = false;
+}
+
+function renderRanking() {
+  rankingBody.innerHTML = "";
+  const sorted = [...state.characters].sort((a, b) => b.rating - a.rating);
+  sorted.forEach((character, index) => {
+    const row = document.createElement("tr");
+    row.innerHTML = `
+      <td>${index + 1}</td>
+      <td>${character.name}</td>
+      <td>${character.rating}</td>
+      <td>${character.wins}勝 ${character.losses}敗 ${character.draws}分</td>
+      <td><button class="remove-btn" data-id="${character.id}">削除</button></td>
+    `;
+    rankingBody.appendChild(row);
+  });
+
+  rankingBody.querySelectorAll(".remove-btn").forEach((button) => {
+    button.addEventListener("click", (event) => {
+      const { id } = event.currentTarget.dataset;
+      removeCharacter(id);
+    });
+  });
+}
+
+function refresh() {
+  renderRanking();
+  renderMatchup();
+}
+
+addCharacterButton.addEventListener("click", addCharacter);
+characterInput.addEventListener("keydown", (event) => {
+  if (event.key === "Enter") {
+    addCharacter();
+  }
+});
+
+voteAButton.addEventListener("click", () => updateRatings(1));
+voteBButton.addEventListener("click", () => updateRatings(0));
+voteDrawButton.addEventListener("click", () => updateRatings(0.5));
+
+resetButton.addEventListener("click", () => {
+  if (confirm("本当にデータをリセットしますか？")) {
+    state = { characters: [] };
+    saveState();
+    refresh();
+  }
+});
+
+refresh();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,174 @@
+:root {
+  color-scheme: light;
+  font-family: "Noto Sans JP", system-ui, sans-serif;
+  background: #f5f6fb;
+  color: #1e1f28;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 32px 16px 48px;
+}
+
+.app {
+  max-width: 960px;
+  margin: 0 auto;
+  display: grid;
+  gap: 24px;
+}
+
+header {
+  text-align: center;
+}
+
+h1 {
+  margin-bottom: 8px;
+  font-size: 2rem;
+}
+
+.panel {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 20px 24px;
+  box-shadow: 0 10px 30px rgba(31, 34, 56, 0.08);
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.form-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+input[type="text"] {
+  flex: 1;
+  min-width: 240px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid #d1d5e2;
+  font-size: 1rem;
+}
+
+button {
+  border: none;
+  border-radius: 8px;
+  padding: 10px 16px;
+  font-weight: 600;
+  cursor: pointer;
+  background: #5b6cff;
+  color: white;
+}
+
+button.ghost {
+  background: transparent;
+  color: #5b6cff;
+  border: 1px solid #b5beff;
+}
+
+button.choice {
+  flex: 1;
+  min-height: 56px;
+  font-size: 1rem;
+}
+
+button.choice.neutral {
+  background: #f2f4ff;
+  color: #4c56a6;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.hint {
+  margin-top: 8px;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.matchup-area {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+  align-items: center;
+  margin: 16px 0;
+  min-height: 24px;
+}
+
+.matchup-card {
+  background: #f6f7ff;
+  border-radius: 12px;
+  padding: 16px;
+  text-align: center;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #2a2f4f;
+}
+
+.matchup-card .side {
+  display: inline-block;
+  margin-bottom: 6px;
+  font-size: 0.8rem;
+  color: #7781c0;
+  letter-spacing: 0.05em;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  text-align: left;
+  padding: 10px;
+  border-bottom: 1px solid #eef0f6;
+  font-size: 0.95rem;
+}
+
+tbody tr:hover {
+  background: #fafbff;
+}
+
+.empty {
+  color: #9aa1b9;
+}
+
+.remove-btn {
+  background: #fff5f5;
+  color: #e05555;
+  border: 1px solid #f3b1b1;
+  padding: 6px 10px;
+  font-size: 0.8rem;
+}
+
+@media (max-width: 640px) {
+  .panel {
+    padding: 16px;
+  }
+
+  button.choice {
+    min-width: 100%;
+  }
+}


### PR DESCRIPTION
### Motivation
- Change the voting choices to a three-way option (left / undecided / right) and make matchup UI clearer by showing left/right character cards.  
- Allow adding one or more favorite characters at once via a comma-separated input to speed up initial population.  
- Keep the app client-side and persist rankings in `localStorage` with the existing Elo-like rating updates.  
- Improve matchup layout and styling for better readability on desktop and mobile.  

### Description
- Updated `index.html` to relabel vote buttons to `左が好き`, `決められない`, `右が好き`, accept comma-separated names in the input placeholder, and render left/right character cards in the matchup area.  
- Modified `script.js` to parse comma (`,` and `、`) separated names, deduplicate against existing characters, support batch creation via `createCharacter`, and wire the three vote buttons to `updateRatings` including draw handling.  
- Reworked `style.css` to use a grid-based `matchup-area` and new `.matchup-card` styling for left/right presentation and responsive behavior.  
- Preserved the existing Elo-style rating logic (`expectedScore` / `updateRatings`), and kept remove and reset flows tied to the UI.  

### Testing
- Started a local static server with `python -m http.server 8000` to serve the updated static site which launched successfully.  
- Executed an automated `Playwright` script to load `/index.html`, add characters, and take a screenshot, but the run failed due to a Chromium launch crash in the container.  
- No unit or integration tests were added for the application logic.  
- No further automated tests were executed after the Playwright failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d68605f408322a6956e13baf5b89d)